### PR TITLE
Fix etherpad dependency name.

### DIFF
--- a/ep_syntaxhighlighting/package.json
+++ b/ep_syntaxhighlighting/package.json
@@ -11,7 +11,7 @@
     "node": "*"
   },
   "dependencies": {
-	"ep_etherpad-lite": "1.0.x"
+	"etherpad-lite": "1.0.x"
   },
   "devDependencies": {},
   "optionalDependencies": {}


### PR DESCRIPTION
I have all of 15 minutes familiarity with nodejs/npm, but this change let me 'npm install path/to/ep_syntaxhighlighting'
