### PR TITLE
ep_syntaxhighlighting: use relative urls

### DIFF
--- a/ep_syntaxhighlighting/Readme.md
+++ b/ep_syntaxhighlighting/Readme.md
@@ -6,7 +6,7 @@ Available syntaxes are displayed in a select element in the etherpad-lite menu b
 ## Adding Syntaxes:
 To add a new syntax variant, copy the javascript file for the new syntax into the EP_ROOT/node_modules/ep_syntaxhighlighting/static/js directory, then add it to the end of EP_ROOT/node_modules/ep_syntaxhighlighting/templates/syntaxHighlightingScripts.ejs as follows:
 
-<script src="/static/plugins/ep_syntaxhighlighting/static/js/shBrushCSharp.js"></script>
+<script src="../static/plugins/ep_syntaxhighlighting/static/js/shBrushCSharp.js"></script>
 
 Finally, add an option to EP_ROOT/node_modules/ep_syntaxhighlighting/templates/syntaxHighlightingEditbarButtons.ejs such as:
 <option value="csharp">C#</option>

--- a/ep_syntaxhighlighting/static/js/syntax.js
+++ b/ep_syntaxhighlighting/static/js/syntax.js
@@ -2,8 +2,8 @@ var padcookie = require('ep_etherpad-lite/static/js/pad_cookie').padcookie;
 
 exports.aceInitInnerdocbodyHead = function (hook_name, args, cb)
 {
-	args.iframeHTML.push('<link rel="stylesheet" type="text/css" href="/static/plugins/ep_syntaxhighlighting/static/css/shCore.css"/>');
-	args.iframeHTML.push('<link rel="stylesheet" type="text/css" href="/static/plugins/ep_syntaxhighlighting/static/css/shThemeDefault.css"/>');
+	args.iframeHTML.push('<link rel="stylesheet" type="text/css" href="../static/plugins/ep_syntaxhighlighting/static/css/shCore.css"/>');
+	args.iframeHTML.push('<link rel="stylesheet" type="text/css" href="../static/plugins/ep_syntaxhighlighting/static/css/shThemeDefault.css"/>');
 }	
 
 exports.acePostWriteDomLineHTML = function (hook_name, args, cb)

--- a/ep_syntaxhighlighting/templates/syntaxHighlightingScripts.ejs
+++ b/ep_syntaxhighlighting/templates/syntaxHighlightingScripts.ejs
@@ -1,19 +1,19 @@
 
-<script src="/static/plugins/ep_syntaxhighlighting/static/js/XRegExp.js"></script>
-<script src="/static/plugins/ep_syntaxhighlighting/static/js/shCore.js"></script>
+<script src="../static/plugins/ep_syntaxhighlighting/static/js/XRegExp.js"></script>
+<script src="../static/plugins/ep_syntaxhighlighting/static/js/shCore.js"></script>
 <script type="text/javascript">
 	require.define("shCore", function(require, exports, module) { exports.SyntaxHighlighter = SyntaxHighlighter; });
 </script>
-<script src="/static/plugins/ep_syntaxhighlighting/static/js/shBrushJava.js"></script>
-<script src="/static/plugins/ep_syntaxhighlighting/static/js/shBrushPhp.js"></script>
-<script src="/static/plugins/ep_syntaxhighlighting/static/js/shBrushPython.js"></script>
-<script src="/static/plugins/ep_syntaxhighlighting/static/js/shBrushRuby.js"></script>
-<script src="/static/plugins/ep_syntaxhighlighting/static/js/shBrushJScript.js"></script>
-<script src="/static/plugins/ep_syntaxhighlighting/static/js/shBrushCpp.js"></script>
-<script src="/static/plugins/ep_syntaxhighlighting/static/js/shBrushCss.js"></script>
-<script src="/static/plugins/ep_syntaxhighlighting/static/js/shBrushPerl.js"></script>
-<script src="/static/plugins/ep_syntaxhighlighting/static/js/shBrushScala.js"></script>
-<script src="/static/plugins/ep_syntaxhighlighting/static/js/shBrushSql.js"></script>
-<script src="/static/plugins/ep_syntaxhighlighting/static/js/shBrushVb.js"></script>
-<script src="/static/plugins/ep_syntaxhighlighting/static/js/shBrushXml.js"></script>
-<script src="/static/plugins/ep_syntaxhighlighting/static/js/shBrushCSharp.js"></script>
+<script src="../static/plugins/ep_syntaxhighlighting/static/js/shBrushJava.js"></script>
+<script src="../static/plugins/ep_syntaxhighlighting/static/js/shBrushPhp.js"></script>
+<script src="../static/plugins/ep_syntaxhighlighting/static/js/shBrushPython.js"></script>
+<script src="../static/plugins/ep_syntaxhighlighting/static/js/shBrushRuby.js"></script>
+<script src="../static/plugins/ep_syntaxhighlighting/static/js/shBrushJScript.js"></script>
+<script src="../static/plugins/ep_syntaxhighlighting/static/js/shBrushCpp.js"></script>
+<script src="../static/plugins/ep_syntaxhighlighting/static/js/shBrushCss.js"></script>
+<script src="../static/plugins/ep_syntaxhighlighting/static/js/shBrushPerl.js"></script>
+<script src="../static/plugins/ep_syntaxhighlighting/static/js/shBrushScala.js"></script>
+<script src="../static/plugins/ep_syntaxhighlighting/static/js/shBrushSql.js"></script>
+<script src="../static/plugins/ep_syntaxhighlighting/static/js/shBrushVb.js"></script>
+<script src="../static/plugins/ep_syntaxhighlighting/static/js/shBrushXml.js"></script>
+<script src="../static/plugins/ep_syntaxhighlighting/static/js/shBrushCSharp.js"></script>

--- a/ep_syntaxhighlighting/templates/syntaxHighlightingStyles.ejs
+++ b/ep_syntaxhighlighting/templates/syntaxHighlightingStyles.ejs
@@ -1,1 +1,1 @@
-<link href="/static/plugins/ep_syntaxhighlighting/static/css/syntax.css" rel="stylesheet">
+<link href="../static/plugins/ep_syntaxhighlighting/static/css/syntax.css" rel="stylesheet">


### PR DESCRIPTION
Hi,

the urls for the scripts and stylesheets in ep_syntaxhighlighting were absolute (/static/...) instead of relative so they didn't load on an etherpad installed behind a reverse proxy and mounted in a subdirectory.

This pull request changes all absolute urls in ep_syntaxhighlighting to relative ones.

Have a nice day,
~robbi5
