### PR TITLE
Update ep_syntaxhighlighting/package.json to remove dependency that breaks install

### DIFF
--- a/ep_syntaxhighlighting/package.json
+++ b/ep_syntaxhighlighting/package.json
@@ -10,9 +10,7 @@
   "engines": {
     "node": "*"
   },
-  "dependencies": {
-    "ep_etherpad-lite": "1.1.x"
-  },
+  "dependencies": {},
   "devDependencies": {},
   "optionalDependencies": {}
 }


### PR DESCRIPTION
Removes the dependency on etherpad-lite. Though the dependency is true, etherpad isn't in NPM, so this dependency makes the install fail. 

Beyond that, the other plugins in this repo lack this dependency, so this seems like a more consistent way to go.
