### PR TITLE
add postAceInit hook to default SELECT element to currently-selected value

### DIFF
--- a/ep_syntaxhighlighting/ep.json
+++ b/ep_syntaxhighlighting/ep.json
@@ -5,7 +5,8 @@
 		"hooks" : {
 			"eejsBlock_scripts": "ep_syntaxhighlighting/static/js/syntax:eejsBlock_scripts",
 			"eejsBlock_styles": "ep_syntaxhighlighting/static/js/syntax:eejsBlock_styles",
-			"eejsBlock_editbarMenuRight": "ep_syntaxhighlighting/static/js/syntax:eejsBlock_editbarMenuRight"
+			"eejsBlock_editbarMenuRight": "ep_syntaxhighlighting/static/js/syntax:eejsBlock_editbarMenuRight",
+			"postAceInit": "ep_syntaxhighlighting/static/js/syntax:postAceInit"
 		},
 		"client_hooks" : {
 			"acePostWriteDomLineHTML": "ep_syntaxhighlighting/static/js/syntax:acePostWriteDomLineHTML",

--- a/ep_syntaxhighlighting/static/js/syntax.js
+++ b/ep_syntaxhighlighting/static/js/syntax.js
@@ -36,3 +36,12 @@ exports.eejsBlock_styles = function (hook_name, args, cb)
 exports.eejsBlock_editbarMenuRight = function (hook_name, args, cb) {
 	args.content = require('ep_etherpad-lite/node/eejs/').require("ep_syntaxhighlighting/templates/syntaxHighlightingEditbarButtons.ejs") + args.content;
 }
+
+exports.postAceInit = function (hook_name, args, cb)
+{
+	// Set SELECT dropdown to currently-selected value
+	var element = document.getElementById('syntaxes');
+	var brush = padcookie.getPref("SH_BRUSH");
+	if (brush !== undefined)
+		element.value = brush;
+}


### PR DESCRIPTION
Now, when the pad reloads, the syntax selector defaults to None again even though one is selected. This will select the currently-selected syntax if one is in use.
