### PR TITLE
don't inline a background color for the language selector

### DIFF
--- a/ep_syntaxhighlighting/templates/syntaxHighlightingEditbarButtons.ejs
+++ b/ep_syntaxhighlighting/templates/syntaxHighlightingEditbarButtons.ejs
@@ -1,4 +1,4 @@
-<li id="syntaxhighlighting" style="width: auto; background: #fff;">
+<li id="syntaxhighlighting" style="width: auto;">
     <select id="syntaxes" onchange="require('ep_etherpad-lite/static/js/pad_cookie').padcookie.setPref('SH_BRUSH', this.options[this.selectedIndex].value); window.location.reload();">
         <option value="undefined" selected>None</option>
         <option value="js">Javascript</option>


### PR DESCRIPTION
Why is this inlined? It doesn't seem to match the styling of the default/built-in buttons, and makes the selector ugly on a non-white background.
