### PR TITLE
Update index.js

### DIFF
--- a/ep_authornames/static/js/index.js
+++ b/ep_authornames/static/js/index.js
@@ -24,17 +24,19 @@ exports.acePostWriteDomLineHTML = function(hook_name, args, cb){
 		}
 	};
 	
-	$(args.node).children('span').map(
-		function() {
-			console.dir(this); 
-			if(this.classList[0]){
-				var mainClass = this.classList[0];
-				if(mainClass.substring(0,7) === 'author-') {
-					this.title = className2AuthorName(mainClass);
+	$(args.node).find('span').each(function(span){
+		$(this).children('span').map(
+			function() {
+				console.dir(this); 
+				if(this.classList[0]){
+					var mainClass = this.classList[0];
+					if(mainClass.substring(0,7) === 'author-') {
+						this.title = className2AuthorName(mainClass);
+					}
 				}
 			}
-		}
-	);
+		);
+	});
 	return cb;
 }
 


### PR DESCRIPTION
If there are text-indent properties, $(args.node).children('span') does not work.
